### PR TITLE
Removed Homepage to fix localhost bug of files not being served

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "landingpage-react-template",
-  "homepage": "https://mighty-odewumi.github.io/qiskit-fall-fest24/",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",


### PR DESCRIPTION
- Images and styles were not being served during local development due to homepage property present in package.json because files are served from an incorrect path unlike GitHub.
- Need to enable before deployment to Github Pages though.